### PR TITLE
Enhance error handling

### DIFF
--- a/lib/eqmi/reader.ex
+++ b/lib/eqmi/reader.ex
@@ -28,10 +28,15 @@ defmodule Eqmi.Reader do
     <<_version, l::binary>> = qmux
     len = :binary.decode_unsigned(l, :little)
 
-    msg = IO.binread(dev, len - 2)
-    <<h::binary-size(3), rest::binary>> = msg
-    header = Eqmi.QmuxHeader.parse(h)
-    send(pid, {:qmux, header, rest})
-    run_priv(pid, dev)
+    if len > 2 do
+      msg = IO.binread(dev, len - 2)
+      <<h::binary-size(3), rest::binary>> = msg
+      header = Eqmi.QmuxHeader.parse(h)
+      send(pid, {:qmux, header, rest})
+      run_priv(pid, dev)
+    else
+      # Lost sync. Perhaps multiple clients accessing the device simultaneously?
+      raise "invalid message"
+    end
   end
 end


### PR DESCRIPTION
Small enhancements I noticed while testing this library on a system where I was not running as root, and previously used qmicli. The first commit is particularly important as it's not otherwise possible to detect that the device wasn't actually allocated